### PR TITLE
Disable zlib to allow macOS build.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
           cd build
           cmake -G Ninja ../llvm -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$PWD/../../lean-llvm -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLLVM_USE_LINKER=lld\
             -DLLVM_ENABLE_PROJECTS="llvm;clang;lld;compiler-rt;libcxx;libcxxabi;libunwind" -DLLVM_LINK_LLVM_DYLIB=ON -DLLVM_CCACHE_BUILD=ON\
-            -DLLVM_ENABLE_LIBXML2=OFF -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_ENABLE_LIBCXX=ON -DLLVM_ENABLE_FFI=OFF\
+            -DLLVM_ENABLE_LIBXML2=OFF -DLLVM_ENABLE_ZLIB=OFF -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_ENABLE_LIBCXX=ON -DLLVM_ENABLE_FFI=OFF\
             `# https://boxbase.org/entries/2018/jun/11/minimal-llvm-build/`\
             -DLLVM_TARGETS_TO_BUILD='AArch64;WebAssembly;X86'\
             `# https://libcxx.llvm.org/BuildingLibcxx.html`\


### PR DESCRIPTION
The macOS builds on trying to link LLVM fail to find zlib symbols:

```
ld64.lld: error: undefined symbol: _ZSTD_compressBound
>>> referenced by /Users/runner/work/lean4/lean4/build/stage1/lib/libLLVMSupport.a(Compression.cpp.o):(symbol llvm::compression::zstd::compress(llvm::ArrayRef<unsigned char>, llvm::SmallVectorImpl<unsigned char>&, int)+0x1e)

ld64.lld: error: undefined symbol: _ZSTD_getErrorName
>>> referenced by /Users/runner/work/lean4/lean4/build/stage1/lib/libLLVMSupport.a(Compression.cpp.o):(symbol llvm::compression::zstd::uncompress(llvm::ArrayRef<unsigned char>, unsigned char*, unsigned long&)+0x41)
>>> referenced by /Users/runner/work/lean4/lean4/build/stage1/lib/libLLVMSupport.a(Compression.cpp.o):(symbol llvm::compression::zstd::uncompress(llvm::ArrayRef<unsigned char>, llvm::SmallVectorImpl<unsigned char>&, unsigned long)+0x6b)

ld64.lld: error: undefined symbol: _ZSTD_decompress
>>> referenced by /Users/runner/work/lean4/lean4/build/stage1/lib/libLLVMSupport.a(Compression.cpp.o):(symbol llvm::compression::zstd::uncompress(llvm::ArrayRef<unsigned char>, unsigned char*, unsigned long&)+0x27)
>>> referenced by /Users/runner/work/lean4/lean4/build/stage1/lib/libLLVMSupport.a(Compression.cpp.o):(symbol llvm::compression::zstd::uncompress(llvm::ArrayRef<unsigned char>, llvm::SmallVectorImpl<unsigned char>&, unsigned long)+0x54)
```

I was not as careful as I should have been in my review of https://github.com/leanprover/lean-llvm/pull/5. I had disabled ZLIB in https://github.com/leanprover/lean-llvm/pull/3, to enable the macOS build to succeed.